### PR TITLE
Bugfix/switched box position

### DIFF
--- a/lib/widgets/draggable_multi_list_view.dart
+++ b/lib/widgets/draggable_multi_list_view.dart
@@ -355,7 +355,7 @@ class _DraggableMultiListViewState extends State<DraggableMultiListView> {
           ? Axis.vertical
           : Axis.horizontal,
       children:
-          (direction == MoveDirection.up || direction == MoveDirection.left)
+          (direction == MoveDirection.down || direction == MoveDirection.right)
               ? [targetBox, movedBox]
               : [movedBox, targetBox],
       onWeightChange: () {

--- a/lib/widgets/movable_box.dart
+++ b/lib/widgets/movable_box.dart
@@ -37,7 +37,7 @@ class _MovableBoxState extends State<MovableBox> {
   bool _showBottomBorder = false;
   bool _showLeftBorder = false;
   bool _showRightBorder = false;
-  static const barSize = 20.0;
+  static const barSize = 50.0;
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
When moving a box it always got placed on the wrong side of the selected box. So if you tried moving box 1 to the left of box 0 it would instead go to the right